### PR TITLE
Integrate AI catalog responder and background worker

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ from routes.roles_routes import roles_bp
 from routes.webhook import webhook_bp
 from routes.tablero_routes import tablero_bp
 from routes.export_routes import export_bp
+from services.ai_worker import start_ai_worker
 
 load_dotenv()
 
@@ -41,6 +42,8 @@ def create_app():
     app.register_blueprint(webhook_bp)
     app.register_blueprint(tablero_bp)
     app.register_blueprint(export_bp)
+
+    start_ai_worker()
 
     # Inicializa BD solo si se pide explícitamente y dentro del app_context
     if os.getenv("INIT_DB_ON_START", "0") == "1":

--- a/config.py
+++ b/config.py
@@ -1,5 +1,13 @@
 import os
 
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 class Config:
     SECRET_KEY = os.getenv('SECRET_KEY')
     META_TOKEN = os.getenv('META_TOKEN')
@@ -20,3 +28,28 @@ class Config:
 
     BASEDIR    = os.path.dirname(os.path.abspath(__file__))
     MEDIA_ROOT = os.getenv("MEDIA_ROOT", os.path.join(BASEDIR, "static", "uploads"))
+
+    OPENAI_API_KEY   = os.getenv('OPENAI_API_KEY')
+    AI_EMBED_MODEL   = os.getenv('AI_EMBED_MODEL', 'text-embedding-3-small')
+    AI_GEN_MODEL     = os.getenv('AI_GEN_MODEL', 'gpt-4o-mini')
+    AI_MODE_DEFAULT  = _env_bool('AI_MODE_ENABLED', False)
+    AI_HANDOFF_STEP  = os.getenv('AI_HANDOFF_STEP', 'ia_chat').strip().lower()
+    AI_VECTOR_STORE_PATH = os.getenv(
+        'AI_VECTOR_STORE_PATH',
+        os.path.join(BASEDIR, 'data', 'catalog_index')
+    )
+    AI_POLL_INTERVAL = float(os.getenv('AI_POLL_INTERVAL', 3))
+    AI_BATCH_SIZE    = int(os.getenv('AI_BATCH_SIZE', 10))
+    AI_CACHE_TTL     = int(os.getenv('AI_CACHE_TTL', 3600))
+    AI_FALLBACK_MESSAGE = os.getenv(
+        'AI_FALLBACK_MESSAGE',
+        'Por ahora no tengo información del catálogo, intentaré más tarde.'
+    )
+    REDIS_URL = os.getenv('REDIS_URL')
+    CATALOG_UPLOAD_DIR = os.getenv(
+        'CATALOG_UPLOAD_DIR',
+        os.path.join(MEDIA_ROOT, 'catalogos')
+    )
+
+    os.makedirs(MEDIA_ROOT, exist_ok=True)
+    os.makedirs(CATALOG_UPLOAD_DIR, exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ mysql-connector-python
 vosk
 ffmpeg-python
 concurrent-futures; python_version < "3.2"
+openai>=1.30.0
+faiss-cpu
+numpy
+pypdf
+redis

--- a/services/ai_responder.py
+++ b/services/ai_responder.py
@@ -1,0 +1,322 @@
+import json
+import logging
+import os
+import threading
+import hashlib
+import re
+from typing import Dict, List, Optional, Tuple
+
+import faiss
+import numpy as np
+from openai import OpenAI
+from pypdf import PdfReader
+
+try:
+    import redis
+except Exception:  # pragma: no cover - redis es opcional
+    redis = None
+
+from config import Config
+from services.db import (
+    log_ai_interaction,
+    set_ai_last_processed_to_latest,
+    update_ai_catalog_metadata,
+)
+
+
+SKU_PATTERN = re.compile(r"\bSKU[:\s-]*([A-Z0-9-]{3,})\b", re.IGNORECASE)
+
+
+class CatalogResponder:
+    """Gestiona la ingesta de catálogos y respuestas basadas en embeddings."""
+
+    _instance: Optional["CatalogResponder"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._client: Optional[OpenAI] = OpenAI(api_key=Config.OPENAI_API_KEY) if Config.OPENAI_API_KEY else None
+        self._index: Optional[faiss.Index] = None
+        self._metadata: List[Dict[str, object]] = []
+        self._index_lock = threading.RLock()
+        self._base_path = Config.AI_VECTOR_STORE_PATH
+        self._index_path = f"{self._base_path}.faiss"
+        self._metadata_path = f"{self._base_path}.json"
+        base_dir = os.path.dirname(self._index_path)
+        if base_dir:
+            os.makedirs(base_dir, exist_ok=True)
+        self._redis = self._init_redis()
+        self._cache_ttl = Config.AI_CACHE_TTL
+        self._last_mtime: float = 0.0
+
+    @classmethod
+    def instance(cls) -> "CatalogResponder":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+        return cls._instance
+
+    # --- utilidades internas -------------------------------------------------
+
+    def _init_redis(self):
+        if not Config.REDIS_URL or redis is None:
+            return None
+        try:
+            client = redis.from_url(Config.REDIS_URL)
+            client.ping()
+            return client
+        except Exception:
+            logging.warning("No se pudo inicializar Redis para caché de IA", exc_info=True)
+            return None
+
+    def _ensure_client(self) -> OpenAI:
+        if self._client is None:
+            if not Config.OPENAI_API_KEY:
+                raise RuntimeError("OPENAI_API_KEY no configurada")
+            self._client = OpenAI(api_key=Config.OPENAI_API_KEY)
+        return self._client
+
+    def _ensure_index_loaded(self) -> None:
+        with self._index_lock:
+            if not os.path.exists(self._index_path) or not os.path.exists(self._metadata_path):
+                self._index = None
+                self._metadata = []
+                self._last_mtime = 0.0
+                return
+            mtime = max(os.path.getmtime(self._index_path), os.path.getmtime(self._metadata_path))
+            if self._index is not None and self._last_mtime == mtime:
+                return
+            self._index = faiss.read_index(self._index_path)
+            with open(self._metadata_path, "r", encoding="utf-8") as fh:
+                self._metadata = json.load(fh)
+            self._last_mtime = mtime
+
+    @staticmethod
+    def _chunk_text(text: str, chunk_size: int = 900, overlap: int = 200) -> List[str]:
+        cleaned = re.sub(r"\s+", " ", text or "").strip()
+        if not cleaned:
+            return []
+        chunks: List[str] = []
+        start = 0
+        length = len(cleaned)
+        while start < length:
+            end = min(length, start + chunk_size)
+            chunk = cleaned[start:end]
+            if chunk:
+                chunks.append(chunk)
+            if end >= length:
+                break
+            start = max(0, end - overlap)
+        return chunks
+
+    @staticmethod
+    def _extract_skus(text: str) -> List[str]:
+        if not text:
+            return []
+        found = SKU_PATTERN.findall(text)
+        seen = set()
+        result: List[str] = []
+        for sku in found:
+            sku_up = sku.strip().upper()
+            if sku_up and sku_up not in seen:
+                seen.add(sku_up)
+                result.append(sku_up)
+        return result
+
+    def _embed_texts(self, texts: List[str]) -> List[List[float]]:
+        client = self._ensure_client()
+        response = client.embeddings.create(model=Config.AI_EMBED_MODEL, input=texts)
+        return [item.embedding for item in response.data]
+
+    def _cache_key(self, question: str) -> str:
+        normalized = question.strip().lower()
+        return hashlib.sha1(normalized.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _build_stats(metadata: List[Dict[str, object]]) -> Dict[str, object]:
+        sources = sorted({str(m.get("source")) for m in metadata if m.get("source")})
+        pages = max((int(m.get("page") or 0) for m in metadata), default=0)
+        return {"chunks": len(metadata), "sources": sources, "pages": pages}
+
+    def reload(self) -> None:
+        """Forza recarga desde disco (usado tras ingesta)."""
+        self._last_mtime = 0.0
+        self._ensure_index_loaded()
+
+    def get_summary(self) -> Dict[str, object]:
+        self._ensure_index_loaded()
+        return self._build_stats(self._metadata)
+
+    # --- flujo principal -----------------------------------------------------
+
+    def ingest_pdf(self, pdf_path: str, source_name: Optional[str] = None) -> Dict[str, object]:
+        """Procesa un PDF y reconstruye el índice FAISS."""
+        reader = PdfReader(pdf_path)
+        metadata: List[Dict[str, object]] = []
+        chunks: List[str] = []
+        for page_number, page in enumerate(reader.pages, start=1):
+            try:
+                page_text = page.extract_text() or ""
+            except Exception:
+                logging.warning("No se pudo extraer texto de la página %s", page_number, exc_info=True)
+                page_text = ""
+            for chunk_idx, chunk in enumerate(self._chunk_text(page_text), start=1):
+                if not chunk.strip():
+                    continue
+                metadata.append(
+                    {
+                        "page": page_number,
+                        "chunk": chunk_idx,
+                        "text": chunk,
+                        "source": source_name or os.path.basename(pdf_path),
+                        "skus": self._extract_skus(chunk),
+                    }
+                )
+                chunks.append(chunk)
+        if not chunks:
+            raise ValueError("El PDF no contiene texto utilizable.")
+
+        embeddings: List[List[float]] = []
+        batch_size = 20
+        for i in range(0, len(chunks), batch_size):
+            batch = chunks[i : i + batch_size]
+            embeddings.extend(self._embed_texts(batch))
+
+        matrix = np.array(embeddings, dtype="float32")
+        if matrix.ndim != 2 or matrix.shape[0] == 0:
+            raise ValueError("No se generaron embeddings válidos.")
+
+        index = faiss.IndexFlatL2(matrix.shape[1])
+        index.add(matrix)
+
+        with self._index_lock:
+            faiss.write_index(index, self._index_path)
+            with open(self._metadata_path, "w", encoding="utf-8") as fh:
+                json.dump(metadata, fh, ensure_ascii=False, indent=2)
+            self._index = index
+            self._metadata = metadata
+            self._last_mtime = max(os.path.getmtime(self._index_path), os.path.getmtime(self._metadata_path))
+
+        stats = self._build_stats(metadata)
+        update_ai_catalog_metadata(stats)
+        set_ai_last_processed_to_latest()
+        return stats
+
+    def answer(self, numero: str, question: str, top_k: int = 4) -> Tuple[Optional[str], List[Dict[str, object]]]:
+        """Genera una respuesta basada en el catálogo."""
+        if not question or not question.strip():
+            return None, []
+
+        self._ensure_index_loaded()
+        if not self._index or not self._metadata:
+            logging.warning("Se solicitó respuesta IA pero el índice está vacío")
+            return None, []
+
+        client = self._ensure_client()
+        normalized_question = question.strip()
+
+        cache_payload = None
+        if self._redis:
+            cache_payload = self._redis.get(self._cache_key(normalized_question))
+        if cache_payload:
+            try:
+                cached = json.loads(cache_payload)
+                answer = cached.get("answer")
+                references = cached.get("references") or []
+            except Exception:
+                logging.warning("No se pudo decodificar caché de IA, se descarta.")
+                answer = None
+                references = []
+                if self._redis:
+                    self._redis.delete(self._cache_key(normalized_question))
+            else:
+                log_ai_interaction(
+                    numero,
+                    normalized_question,
+                    answer,
+                    {"references": references, "from_cache": True},
+                )
+                return answer, references
+
+        query_embedding = self._embed_texts([normalized_question])[0]
+        query_vector = np.array([query_embedding], dtype="float32")
+
+        with self._index_lock:
+            distances, indices = self._index.search(query_vector, min(top_k, len(self._metadata)))
+
+        references: List[Dict[str, object]] = []
+        for idx, dist in zip(indices[0], distances[0]):
+            if idx < 0 or idx >= len(self._metadata):
+                continue
+            ref = dict(self._metadata[idx])
+            ref["score"] = float(dist)
+            references.append(ref)
+
+        prompt = self._build_prompt(normalized_question, references)
+        answer = self._generate_response(client, prompt)
+
+        metadata_log = {"references": references, "from_cache": False}
+        if answer:
+            if self._redis:
+                try:
+                    payload = json.dumps({"answer": answer, "references": references}, ensure_ascii=False)
+                    self._redis.setex(self._cache_key(normalized_question), self._cache_ttl, payload)
+                except Exception:
+                    logging.warning("No se pudo almacenar la respuesta en Redis", exc_info=True)
+            log_ai_interaction(numero, normalized_question, answer, metadata_log)
+        return answer, references
+
+    # --- helpers de generación -----------------------------------------------
+
+    @staticmethod
+    def _build_prompt(question: str, references: List[Dict[str, object]]) -> str:
+        if not references:
+            return (
+                "El catálogo está vacío. Si no encuentras información, responde que no está disponible.\n"
+                f"Pregunta: {question}"
+            )
+        context_parts = []
+        for idx, ref in enumerate(references, start=1):
+            sku_text = ", ".join(ref.get("skus") or []) or "sin SKU"
+            context_parts.append(
+                f"[Fragmento {idx}] Página {ref.get('page', '?')} ({sku_text})\n{ref.get('text')}"
+            )
+        context = "\n\n".join(context_parts)
+        return (
+            "Actúas como asesor comercial. Usa únicamente el catálogo proporcionado para responder.\n"
+            "Entrega la respuesta en español neutro, proponiendo opciones con SKU y una breve invitación a continuar la compra.\n"
+            "Si el dato no aparece, informa que no está en el catálogo.\n\n"
+            f"Pregunta del cliente: {question}\n\n"
+            f"Catálogo disponible:\n{context}"
+        )
+
+    def _generate_response(self, client: OpenAI, prompt: str) -> Optional[str]:
+        try:
+            response = client.responses.create(
+                model=Config.AI_GEN_MODEL,
+                input=[
+                    {
+                        "role": "system",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Eres un asistente experto en productos. Utiliza solo la información suministrada en el contexto."
+                                    " Indica SKU y página cuando sea posible."
+                                ),
+                            }
+                        ],
+                    },
+                    {"role": "user", "content": [{"type": "text", "text": prompt}]},
+                ],
+                temperature=0.2,
+            )
+            text = (response.output_text or "").strip()
+            return text or None
+        except Exception:
+            logging.exception("Fallo al generar respuesta con OpenAI")
+            return None
+
+
+def get_catalog_responder() -> CatalogResponder:
+    """Shortcut para acceder al singleton."""
+    return CatalogResponder.instance()

--- a/services/ai_worker.py
+++ b/services/ai_worker.py
@@ -1,0 +1,90 @@
+import logging
+import threading
+import time
+from typing import Optional
+
+from config import Config
+from services.ai_responder import get_catalog_responder
+from services.db import (
+    get_ai_settings,
+    get_messages_for_ai,
+    update_ai_last_processed,
+    update_chat_state,
+)
+from services.whatsapp_api import enviar_mensaje
+
+
+_worker: Optional["AIWorker"] = None
+_worker_lock = threading.Lock()
+
+
+class AIWorker(threading.Thread):
+    """Hilo en segundo plano que detecta nuevos mensajes y responde con IA."""
+
+    def __init__(self) -> None:
+        super().__init__(name="AIWorker", daemon=True)
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self) -> None:
+        responder = get_catalog_responder()
+        poll_seconds = max(float(Config.AI_POLL_INTERVAL), 1.0)
+        while not self._stop_event.is_set():
+            try:
+                settings = get_ai_settings()
+                if not settings.get("enabled") or not Config.AI_HANDOFF_STEP:
+                    time.sleep(poll_seconds)
+                    continue
+
+                last_id = settings.get("last_processed_message_id") or 0
+                mensajes = get_messages_for_ai(last_id, Config.AI_HANDOFF_STEP, Config.AI_BATCH_SIZE)
+                if not mensajes:
+                    time.sleep(poll_seconds)
+                    continue
+
+                for row in mensajes:
+                    message_id = row["id"]
+                    numero = row["numero"]
+                    texto = row["mensaje"]
+                    try:
+                        answer, _references = responder.answer(numero, texto)
+                    except Exception:
+                        logging.exception("Error generando respuesta IA para %s", numero)
+                        update_ai_last_processed(message_id)
+                        continue
+
+                    if answer:
+                        enviar_mensaje(
+                            numero,
+                            answer,
+                            tipo="bot",
+                            tipo_respuesta="texto",
+                            step=Config.AI_HANDOFF_STEP,
+                        )
+                        update_chat_state(numero, Config.AI_HANDOFF_STEP, "ia_activa")
+                    else:
+                        fallback = (Config.AI_FALLBACK_MESSAGE or "").strip()
+                        if fallback:
+                            enviar_mensaje(
+                                numero,
+                                fallback,
+                                tipo="bot",
+                                tipo_respuesta="texto",
+                                step=Config.AI_HANDOFF_STEP,
+                            )
+                            update_chat_state(numero, Config.AI_HANDOFF_STEP, "ia_fallback")
+                    update_ai_last_processed(message_id)
+            except Exception:
+                logging.exception("Fallo general en el worker de IA")
+            time.sleep(poll_seconds)
+
+
+def start_ai_worker() -> AIWorker:
+    global _worker
+    with _worker_lock:
+        if _worker is None:
+            _worker = AIWorker()
+            _worker.start()
+    return _worker

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -9,6 +9,9 @@
 </div>
 
 <h2>Configuración de Reglas</h2>
+<p style="margin: 12px 0;">
+    <a class="btn-primary" href="{{ url_for('configuracion.ia_settings') }}">Configurar modo IA conversacional</a>
+</p>
 <p>Para reglas de medición usa "*" en <em>Texto del usuario</em> y define la fórmula en <em>Cálculo</em> con variables como <code>medida</code>, <code>p1</code> o <code>p2</code>. El comodín "*" permite avanzar al siguiente paso sin validar el texto recibido: si es la única regla del paso se ejecutará de forma automática; si hay más reglas, actuará como opción por defecto. Opcionalmente indica un <em>Handler</em> para delegar el cálculo a código externo.</p>
 
 <form id="reglaForm" method="POST" enctype="multipart/form-data">

--- a/templates/ia_settings.html
+++ b/templates/ia_settings.html
@@ -1,0 +1,63 @@
+{% extends 'base.html' %}
+{% block title %}Modo IA{% endblock %}
+{% block body_class %}page{% endblock %}
+{% block content %}
+<div class="top-right">
+    <a href="{{ url_for('configuracion.configuracion') }}">
+        <button class="back-btn btn-primary">Volver a reglas</button>
+    </a>
+</div>
+
+<h2>Modo IA conversacional</h2>
+
+{% if message %}
+<div style="background:#e8f5e9;color:#256029;padding:12px;border-radius:8px;margin-bottom:12px;">
+    {{ message }}
+</div>
+{% endif %}
+{% if error %}
+<div style="background:#fdecea;color:#c62828;padding:12px;border-radius:8px;margin-bottom:12px;">
+    {{ error }}
+</div>
+{% endif %}
+
+<div style="border:1px solid #e0e0e0;border-radius:8px;padding:16px;margin-bottom:20px;">
+    <h3>Estado general</h3>
+    <p><strong>IA activada:</strong> {{ 'Sí' if settings.enabled else 'No' }}</p>
+    <p><strong>Paso de traspaso:</strong> {{ handoff_step or 'No definido' }}</p>
+    <p><strong>OPENAI_API_KEY configurada:</strong> {{ 'Sí' if has_openai_key else 'No' }}</p>
+    <p><strong>Última actualización de catálogo:</strong> {{ settings.catalog_updated_at or 'Sin registros' }}</p>
+    <ul>
+        <li>Fragmentos indexados: {{ summary.chunks or 0 }}</li>
+        <li>Páginas detectadas: {{ summary.pages or 0 }}</li>
+        <li>Fuentes: {{ summary.sources|join(', ') if summary.sources else 'Sin catálogos cargados' }}</li>
+    </ul>
+    <form method="POST" style="margin-top:12px;">
+        <input type="hidden" name="action" value="toggle">
+        <input type="hidden" name="enabled" value="{{ 0 if settings.enabled else 1 }}">
+        <button class="btn-primary" type="submit">
+            {{ 'Desactivar IA' if settings.enabled else 'Activar IA' }}
+        </button>
+    </form>
+    <p style="margin-top:12px;font-size:14px;color:#424242;">
+        Para que la IA responda automáticamente, crea una regla que cambie el paso del cliente a <code>{{ handoff_step }}</code> después del mensaje de bienvenida.
+    </p>
+</div>
+
+<div style="border:1px solid #e0e0e0;border-radius:8px;padding:16px;">
+    <h3>Procesar catálogo PDF</h3>
+    <p>El archivo se convertirá en texto, se dividirá en fragmentos y se generarán embeddings con <code>{{ Config.AI_EMBED_MODEL }}</code>. El bot usará <code>{{ Config.AI_GEN_MODEL }}</code> para responder.</p>
+    {% if not has_openai_key %}
+    <p style="color:#c62828;">Configura la variable <code>OPENAI_API_KEY</code> antes de cargar el catálogo.</p>
+    {% endif %}
+    <form method="POST" enctype="multipart/form-data">
+        <input type="hidden" name="action" value="ingest">
+        <label for="catalogo">Catálogo PDF:</label>
+        <input id="catalogo" name="catalogo" type="file" accept="application/pdf" {% if not has_openai_key %}disabled{% endif %}>
+        <button class="btn-primary" type="submit" {% if not has_openai_key %}disabled{% endif %}>Procesar catálogo</button>
+    </form>
+    <p style="margin-top:12px;font-size:14px;color:#424242;">
+        Cada respuesta registrará los SKU y páginas consultados en la tabla de auditoría (<code>ia_logs</code>) y se cacheará en Redis si está disponible.
+    </p>
+</div>
+{% endblock %}

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -9,6 +9,9 @@
 </div>
 
 <h2>Reglas</h2>
+<p style="margin: 12px 0;">
+    <a class="btn-primary" href="{{ url_for('configuracion.ia_settings') }}">Configurar modo IA conversacional</a>
+</p>
 <p>Para reglas de medición usa "*" en <em>Texto del usuario</em> y define la fórmula en <em>Cálculo</em> con variables como <code>medida</code>, <code>p1</code> o <code>p2</code>. El comodín "*" permite avanzar al siguiente paso sin validar el texto recibido: si es la única regla del paso se ejecutará automáticamente; si hay más reglas, actuará como opción por defecto. Opcionalmente indica un <em>Handler</em> para delegar el cálculo a código externo.</p>
 
 <form id="reglaForm" method="POST" enctype="multipart/form-data">


### PR DESCRIPTION
## Summary
- add an OpenAI-based catalog responder with FAISS embeddings, Redis caching and catalog ingestion for PDF files
- expose admin UI to ingest catalogs, toggle AI mode and control the IA hand-off step while keeping the first reply rule-driven
- extend configuration, database schema and WhatsApp webhook to cooperate with the AI worker and document the new flow

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3f93072e083238437df13d44c8c3d