### PR TITLE
Add pdfium text extraction fallback before OCR

### DIFF
--- a/services/ai_responder.py
+++ b/services/ai_responder.py
@@ -147,6 +147,60 @@ class CatalogResponder:
         pages = max((int(m.get("page") or 0) for m in metadata), default=0)
         return {"chunks": len(metadata), "sources": sources, "pages": pages}
 
+    def _extract_text_via_pdfium(
+        self, pdf_path: str, page_number: int, pdfium_context: Dict[str, object]
+    ) -> str:
+        """Intenta una extracción directa de texto usando pypdfium2 antes de recurrir a OCR."""
+
+        if pdfium is None:
+            pdfium_context.setdefault("error", "missing_libs")
+            return ""
+
+        if pdfium_context.get("error") in {"init_failed", "page_failed", "text_failed"}:
+            return ""
+
+        if pdfium_context.get("doc") is None:
+            try:
+                pdfium_context["doc"] = pdfium.PdfDocument(pdf_path)
+            except Exception:
+                logging.warning(
+                    "No se pudo abrir el PDF con pypdfium2 para extracción de texto", exc_info=True
+                )
+                pdfium_context["error"] = "init_failed"
+                return ""
+
+        doc = pdfium_context.get("doc")
+        try:
+            page = doc[page_number - 1]
+        except Exception:
+            logging.warning(
+                "No se pudo acceder a la página %s con pypdfium2", page_number, exc_info=True
+            )
+            pdfium_context["error"] = "page_failed"
+            return ""
+
+        textpage = None
+        text = ""
+        try:
+            textpage = page.get_textpage()
+            text = textpage.get_text_range() or ""
+        except Exception:
+            logging.warning(
+                "Falló la extracción de texto vía pypdfium2 en la página %s", page_number, exc_info=True
+            )
+            pdfium_context["error"] = "text_failed"
+        finally:
+            if textpage is not None:
+                try:
+                    textpage.close()
+                except Exception:
+                    pass
+            page.close()
+
+        if text.strip():
+            pdfium_context.pop("error", None)
+        return text
+
     def _extract_text_via_ocr(
         self, pdf_path: str, page_number: int, ocr_context: Dict[str, object]
     ) -> str:
@@ -251,6 +305,7 @@ class CatalogResponder:
         reader = PdfReader(pdf_path)
         metadata: List[Dict[str, object]] = []
         chunks: List[str] = []
+        pdfium_text_context: Dict[str, object] = {"doc": None}
         ocr_context: Dict[str, object] = {"doc": None}
         try:
             for page_number, page in enumerate(reader.pages, start=1):
@@ -260,8 +315,12 @@ class CatalogResponder:
                     logging.warning("No se pudo extraer texto de la página %s", page_number, exc_info=True)
                     page_text = ""
                 if not page_text.strip():
-                    ocr_text = self._extract_text_via_ocr(pdf_path, page_number, ocr_context)
-                    page_text = ocr_text or ""
+                    pdfium_text = self._extract_text_via_pdfium(pdf_path, page_number, pdfium_text_context)
+                    if pdfium_text.strip():
+                        page_text = pdfium_text
+                    else:
+                        ocr_text = self._extract_text_via_ocr(pdf_path, page_number, ocr_context)
+                        page_text = ocr_text or ""
                 for chunk_idx, chunk in enumerate(self._chunk_text(page_text), start=1):
                     if not chunk.strip():
                         continue
@@ -276,15 +335,17 @@ class CatalogResponder:
                     )
                     chunks.append(chunk)
         finally:
-            doc = ocr_context.get("doc")
-            if doc is not None:
-                try:
-                    doc.close()
-                except Exception:
-                    pass
+            for ctx in (pdfium_text_context, ocr_context):
+                doc = ctx.get("doc")
+                if doc is not None:
+                    try:
+                        doc.close()
+                    except Exception:
+                        pass
 
         if not chunks:
             error_reason = ocr_context.get("error")
+            pdfium_error = pdfium_text_context.get("error")
             if error_reason == "missing_libs":
                 raise ValueError(
                     "El PDF no contiene texto utilizable y faltan dependencias de OCR (pypdfium2/pytesseract)."
@@ -297,31 +358,16 @@ class CatalogResponder:
                 raise ValueError(
                     "No se pudo extraer texto del PDF ni con OCR, revisa la calidad del archivo."
                 )
+            if pdfium_error == "missing_libs" and Config.AI_OCR_ENABLED:
+                raise ValueError(
+                    "El PDF no contiene texto utilizable y pypdfium2 no está instalado para intentar una extracción avanzada."
+                )
+            if pdfium_error in {"init_failed", "page_failed", "text_failed"}:
+                logging.warning("No se pudo extraer texto usando pypdfium2; se continuará con el mensaje genérico.")
             if Config.AI_OCR_ENABLED:
                 raise ValueError(
                     "El PDF no contiene texto utilizable incluso con OCR."
                 )
-=======
-        for page_number, page in enumerate(reader.pages, start=1):
-            try:
-                page_text = page.extract_text() or ""
-            except Exception:
-                logging.warning("No se pudo extraer texto de la página %s", page_number, exc_info=True)
-                page_text = ""
-            for chunk_idx, chunk in enumerate(self._chunk_text(page_text), start=1):
-                if not chunk.strip():
-                    continue
-                metadata.append(
-                    {
-                        "page": page_number,
-                        "chunk": chunk_idx,
-                        "text": chunk,
-                        "source": source_name or os.path.basename(pdf_path),
-                        "skus": self._extract_skus(chunk),
-                    }
-                )
-                chunks.append(chunk)
-        if not chunks:
             raise ValueError("El PDF no contiene texto utilizable.")
 
         embeddings: List[List[float]] = []


### PR DESCRIPTION
## Summary
- add a pypdfium2-based text extraction fallback before invoking OCR so image-free PDFs can be ingested without Tesseract
- ensure pdfium resources are released correctly and improve error reporting when advanced extraction dependencies are missing

## Testing
- python -m compileall services/ai_responder.py

------
https://chatgpt.com/codex/tasks/task_e_68d407274d1c832398b96980c4be782e