### PR TITLE
Install OCR dependencies in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     default-libmysqlclient-dev \
     pkg-config \
+    tesseract-ocr \
+    tesseract-ocr-spa \
+    libgl1 \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python deps first (better layer caching)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ sudo apt-get update && sudo apt-get install -y tesseract-ocr tesseract-ocr-spa
 ```
 En macOS puedes usar Homebrew (`brew install tesseract tesseract-lang`), y en Windows descarga el instalador oficial. Ajusta la variable `AI_OCR_LANG` si tu instalación no incluye español.
 
+> ℹ️ Si ejecutas la aplicación con Docker (incluyendo Docker Desktop en Windows/macOS), la imagen definida en `Dockerfile` ya instala `tesseract-ocr`, el paquete de idioma en español y dependencias como `ffmpeg`, por lo que no necesitas preparar el host manualmente para procesar catálogos PDF.
+
 ## Instalación local
 ```bash
 python -m venv .venv


### PR DESCRIPTION
## Summary
- install Tesseract (with Spanish language pack) and multimedia libs in the Docker image so OCR works out of the box
- document that the Docker workflow already bundles OCR/ffmpeg dependencies, simplifying Windows and macOS setups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4180e44d0832398599d37823c3bc7