### PR TITLE
Prevent duplicate ia_settings inserts when processing AI catalog

### DIFF
--- a/services/db.py
+++ b/services/db.py
@@ -647,13 +647,16 @@ def update_ai_last_processed(message_id):
         (int(message_id),),
     )
     if c.rowcount == 0:
-        c.execute(
-            """
-            INSERT INTO ia_settings (id, enabled, last_processed_message_id, vector_store_path, catalog_updated_at, catalog_stats, updated_at)
-            VALUES (1, %s, %s, %s, NULL, NULL, NOW())
-            """,
-            (1 if Config.AI_MODE_DEFAULT else 0, int(message_id), Config.AI_VECTOR_STORE_PATH),
-        )
+        c.execute("SELECT 1 FROM ia_settings WHERE id=1 LIMIT 1")
+        exists = c.fetchone()
+        if not exists:
+            c.execute(
+                """
+                INSERT INTO ia_settings (id, enabled, last_processed_message_id, vector_store_path, catalog_updated_at, catalog_stats, updated_at)
+                VALUES (1, %s, %s, %s, NULL, NULL, NOW())
+                """,
+                (1 if Config.AI_MODE_DEFAULT else 0, int(message_id), Config.AI_VECTOR_STORE_PATH),
+            )
     conn.commit()
     conn.close()
 
@@ -668,13 +671,16 @@ def set_ai_last_processed_to_latest():
         (last,),
     )
     if c.rowcount == 0:
-        c.execute(
-            """
-            INSERT INTO ia_settings (id, enabled, last_processed_message_id, vector_store_path, catalog_updated_at, catalog_stats, updated_at)
-            VALUES (1, %s, %s, %s, NULL, NULL, NOW())
-            """,
-            (1 if Config.AI_MODE_DEFAULT else 0, last, Config.AI_VECTOR_STORE_PATH),
-        )
+        c.execute("SELECT 1 FROM ia_settings WHERE id=1 LIMIT 1")
+        exists = c.fetchone()
+        if not exists:
+            c.execute(
+                """
+                INSERT INTO ia_settings (id, enabled, last_processed_message_id, vector_store_path, catalog_updated_at, catalog_stats, updated_at)
+                VALUES (1, %s, %s, %s, NULL, NULL, NOW())
+                """,
+                (1 if Config.AI_MODE_DEFAULT else 0, last, Config.AI_VECTOR_STORE_PATH),
+            )
     conn.commit()
     conn.close()
     return last
@@ -689,13 +695,16 @@ def update_ai_catalog_metadata(stats):
         (payload, Config.AI_VECTOR_STORE_PATH),
     )
     if c.rowcount == 0:
-        c.execute(
-            """
-            INSERT INTO ia_settings (id, enabled, last_processed_message_id, vector_store_path, catalog_updated_at, catalog_stats, updated_at)
-            VALUES (1, %s, 0, %s, NOW(), %s, NOW())
-            """,
-            (1 if Config.AI_MODE_DEFAULT else 0, Config.AI_VECTOR_STORE_PATH, payload),
-        )
+        c.execute("SELECT 1 FROM ia_settings WHERE id=1 LIMIT 1")
+        exists = c.fetchone()
+        if not exists:
+            c.execute(
+                """
+                INSERT INTO ia_settings (id, enabled, last_processed_message_id, vector_store_path, catalog_updated_at, catalog_stats, updated_at)
+                VALUES (1, %s, 0, %s, NOW(), %s, NOW())
+                """,
+                (1 if Config.AI_MODE_DEFAULT else 0, Config.AI_VECTOR_STORE_PATH, payload),
+            )
     conn.commit()
     conn.close()
 


### PR DESCRIPTION
## Summary
- avoid inserting duplicate ia_settings rows when UPDATE finds no changed rows by verifying existence before inserting

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d49086c84c83238fb15efcb73ca1cb