### PR TITLE
Fix OpenAI responses payload content type

### DIFF
--- a/services/ai_responder.py
+++ b/services/ai_responder.py
@@ -794,7 +794,7 @@ class CatalogResponder:
                         "role": "system",
                         "content": [
                             {
-                                "type": "text",
+                                "type": "input_text",
                                 "text": (
                                     "Eres un asistente experto en productos. Utiliza solo la información suministrada en el contexto."
                                     " Indica SKU y página cuando sea posible."
@@ -802,7 +802,12 @@ class CatalogResponder:
                             }
                         ],
                     },
-                    {"role": "user", "content": [{"type": "text", "text": prompt}]},
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": prompt},
+                        ],
+                    },
                 ],
                 temperature=0.2,
             )


### PR DESCRIPTION
## Summary
- update the AI responder to use the new `input_text` content type required by the OpenAI Responses API for system and user messages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4992c2f348323b03de6dee57968c9