### PR TITLE
Allow blank responses for AI handoff rules

### DIFF
--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -343,7 +343,12 @@ def _reglas_view(template_name):
                 except Exception:
                     pass
             reglas.append(d)
-        return render_template(template_name, reglas=reglas)
+        ai_handoff_step = (Config.AI_HANDOFF_STEP or '').strip().lower()
+        return render_template(
+            template_name,
+            reglas=reglas,
+            ai_handoff_step=ai_handoff_step,
+        )
     finally:
         conn.close()
 

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -129,14 +129,20 @@ def dispatch_rule(numero, regla, step=None):
                     regla_id=regla_id,
                 )
     else:
-        enviar_mensaje(
-            numero,
-            resp,
-            tipo_respuesta=tipo_resp,
-            opciones=opts,
-            step=current_step,
-            regla_id=regla_id,
+        should_skip = (
+            is_ai_handoff_step
+            and tipo_resp == 'texto'
+            and not (resp or '').strip()
         )
+        if not should_skip:
+            enviar_mensaje(
+                numero,
+                resp,
+                tipo_respuesta=tipo_resp,
+                opciones=opts,
+                step=current_step,
+                regla_id=regla_id,
+            )
     if rol_kw:
         conn = get_connection(); c = conn.cursor()
         c.execute("SELECT id FROM roles WHERE keyword=%s", (rol_kw,))

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -24,7 +24,10 @@
     <input type="text" id="input_text" name="input_text" placeholder="palabra1, palabra2" required>
 
     <label for="respuesta">Respuesta del bot:</label>
-    <textarea id="respuesta" name="respuesta" rows="4" required></textarea>
+    <textarea id="respuesta" name="respuesta" rows="4" required data-default-placeholder=""></textarea>
+    <small id="respuestaHint" style="display:none;" class="form-hint">
+        Si dejas este campo vacío en el paso de traspaso a la IA, el bot no enviará mensaje y la respuesta llegará directamente desde la IA.
+    </small>
 
     <label for="siguiente_step">Siguiente paso (puedes ingresar varios pasos separados por comas):</label>
     <input type="text" id="siguiente_step" name="siguiente_step" placeholder="paso1, paso2">
@@ -200,10 +203,39 @@ document.getElementById('tipo').addEventListener('change', () => {
 });
 const form = document.getElementById('reglaForm');
 form.addEventListener('submit', prepareOptions);
+const aiHandoffStep = '{{ ai_handoff_step or "" }}';
+let respuestaDefaultPlaceholder = '';
+
+function updateRespuestaRequirement() {
+    const stepInput = document.getElementById('step');
+    const respuestaField = document.getElementById('respuesta');
+    const hint = document.getElementById('respuestaHint');
+    if (!respuestaDefaultPlaceholder) {
+        respuestaDefaultPlaceholder = respuestaField.getAttribute('data-default-placeholder') || respuestaField.getAttribute('placeholder') || '';
+    }
+    const stepValue = (stepInput.value || '').trim().toLowerCase();
+    const isAiStep = aiHandoffStep && stepValue === aiHandoffStep;
+    respuestaField.required = !isAiStep;
+    if (isAiStep) {
+        respuestaField.placeholder = 'La IA responderá automáticamente por API.';
+        if (hint) {
+            hint.style.display = 'block';
+        }
+    } else {
+        respuestaField.placeholder = respuestaDefaultPlaceholder;
+        if (hint) {
+            hint.style.display = 'none';
+        }
+    }
+}
+
+document.getElementById('step').addEventListener('input', updateRespuestaRequirement);
+
 window.addEventListener('DOMContentLoaded', () => {
     toggleMediaFields();
     toggleListFields();
     toggleButtonFields();
+    updateRespuestaRequirement();
 });
 
 function cargarRegla(regla) {
@@ -244,6 +276,7 @@ function cargarRegla(regla) {
     toggleMediaFields();
     toggleListFields();
     toggleButtonFields();
+    updateRespuestaRequirement();
 }
 </script>
 {% endblock %}

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -24,7 +24,10 @@
     <input type="text" id="input_text" name="input_text" placeholder="palabra1, palabra2" required>
 
     <label for="respuesta">Respuesta del bot:</label>
-    <textarea id="respuesta" name="respuesta" rows="4" required></textarea>
+    <textarea id="respuesta" name="respuesta" rows="4" required data-default-placeholder=""></textarea>
+    <small id="respuestaHint" style="display:none;" class="form-hint">
+        Si dejas este campo vacío en el paso de traspaso a la IA, el bot no enviará mensaje y la respuesta llegará directamente desde la IA.
+    </small>
 
     <label for="siguiente_step">Siguiente paso (puedes ingresar varios pasos separados por comas):</label>
     <input type="text" id="siguiente_step" name="siguiente_step" placeholder="paso1, paso2">
@@ -206,10 +209,38 @@ document.getElementById('tipo').addEventListener('change', () => {
 });
 const form = document.getElementById('reglaForm');
 form.addEventListener('submit', prepareOptions);
+const aiHandoffStep = '{{ ai_handoff_step or "" }}';
+let respuestaDefaultPlaceholder = '';
+
+function updateRespuestaRequirement() {
+    const stepInput = document.getElementById('step');
+    const respuestaField = document.getElementById('respuesta');
+    const hint = document.getElementById('respuestaHint');
+    if (!respuestaDefaultPlaceholder) {
+        respuestaDefaultPlaceholder = respuestaField.getAttribute('data-default-placeholder') || respuestaField.getAttribute('placeholder') || '';
+    }
+    const stepValue = (stepInput.value || '').trim().toLowerCase();
+    const isAiStep = aiHandoffStep && stepValue === aiHandoffStep;
+    respuestaField.required = !isAiStep;
+    if (isAiStep) {
+        respuestaField.placeholder = 'La IA responderá automáticamente por API.';
+        if (hint) {
+            hint.style.display = 'block';
+        }
+    } else {
+        respuestaField.placeholder = respuestaDefaultPlaceholder;
+        if (hint) {
+            hint.style.display = 'none';
+        }
+    }
+}
+
+document.getElementById('step').addEventListener('input', updateRespuestaRequirement);
 window.addEventListener('DOMContentLoaded', () => {
     toggleMediaFields();
     toggleListFields();
     toggleButtonFields();
+    updateRespuestaRequirement();
 });
 
 function cargarRegla(regla) {
@@ -250,6 +281,7 @@ function cargarRegla(regla) {
     toggleMediaFields();
     toggleListFields();
     toggleButtonFields();
+    updateRespuestaRequirement();
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expose the configured AI handoff step to the rules views and relax the response field when editing that step
- show UI guidance so administrators can leave the bot response empty on the AI handoff step
- prevent dispatching empty WhatsApp messages when a rule on the handoff step has no response so the AI reply is sent directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5728a52a08323ae3909c0db64bbbd