### PR TITLE
Evitar que el worker IA responda el saludo inicial

### DIFF
--- a/services/db.py
+++ b/services/db.py
@@ -804,10 +804,11 @@ def get_messages_for_ai(after_id, handoff_step, limit):
            AND m.tipo = 'cliente'
            AND TRIM(COALESCE(m.mensaje, '')) <> ''
            AND LOWER(COALESCE(cs.step, '')) = %s
+           AND LOWER(COALESCE(m.step, '')) = %s
          ORDER BY m.id ASC
          LIMIT %s
         """,
-        (after_id, (handoff_step or '').lower(), limit),
+        (after_id, (handoff_step or '').lower(), (handoff_step or '').lower(), limit),
     )
     rows = c.fetchall()
     conn.close()


### PR DESCRIPTION
## Summary
- filtrar los mensajes que procesa el worker IA para asegurar que correspondan al paso de handoff configurado
- evitar que la IA responda el primer mensaje que únicamente dispara el mensaje de bienvenida

## Testing
- no se realizaron pruebas; no aplica


------
https://chatgpt.com/codex/tasks/task_e_68d58c564f3c8323bd5c714ced33f865