### PR TITLE
Evitar duplicar mensajes al procesar transcripciones

### DIFF
--- a/services/tasks.py
+++ b/services/tasks.py
@@ -23,7 +23,9 @@ def process_audio(
         update_mensaje_texto(mensaje_id, texto)
 
         if texto:
-            handle_text_message(from_number, texto)
+            # El mensaje original ya fue almacenado como tipo 'audio'.
+            # Evitamos crear un duplicado marcándolo como texto nuevamente.
+            handle_text_message(from_number, texto, save=False)
         else:
             enviar_mensaje(
                 from_number,


### PR DESCRIPTION
## Summary
- evita insertar un mensaje duplicado cuando se procesa la transcripción de un audio
- reutiliza el pipeline de reglas sin volver a guardar el texto transcrito

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d59344e4108323a3d5b542e8ed5a1a