### PR TITLE
Ensure webhook verification responses use plain text

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -2,7 +2,7 @@ import os
 import logging
 import threading
 import json
-from flask import Blueprint, request, jsonify, url_for
+from flask import Blueprint, request, jsonify, url_for, Response
 from datetime import datetime
 from config import Config
 from services.db import (
@@ -363,8 +363,8 @@ def webhook():
         token     = request.args.get('hub.verify_token')
         challenge = request.args.get('hub.challenge')
         if token == VERIFY_TOKEN:
-            return challenge, 200
-        return 'Forbidden', 403
+            return Response(challenge or '', status=200, mimetype='text/plain')
+        return Response('Forbidden', status=403, mimetype='text/plain')
 
     data = request.get_json() or {}
     if not data.get('object'):


### PR DESCRIPTION
## Summary
- wrap the webhook GET verification responses in Flask Response objects with text/plain mimetype
- ensure the forbidden branch also emits a plain text payload to avoid implicit HTML

## Testing
- curl -i "http://127.0.0.1:5000/webhook?hub.verify_token=testtoken&hub.challenge=hola"
- curl -i "http://127.0.0.1:5000/webhook?hub.verify_token=bad"


------
https://chatgpt.com/codex/tasks/task_e_68daadfe4af08323973fbf93cf95d7fd