### PR TITLE
Group flow responses by phone number

### DIFF
--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -14,16 +14,23 @@
     <thead>
         <tr>
             <th>Número</th>
-            <th>Fecha</th>
-            <th>Respuesta del flow</th>
+            <th>Respuestas del flow</th>
         </tr>
     </thead>
     <tbody>
         {% for response in flow_responses %}
         <tr>
             <td>{{ response.numero }}</td>
-            <td>{{ response.timestamp }}</td>
-            <td>{{ response.mensaje }}</td>
+            <td>
+                <ul class="flow-responses-list">
+                    {% for resp in response.respuestas %}
+                    <li>
+                        <span class="flow-response-timestamp">{{ resp.timestamp }}</span>
+                        <div class="flow-response-message">{{ resp.mensaje }}</div>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </td>
         </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- group stored bot responses by phone number before rendering
- update the responses template to display each number with its related messages and timestamps

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03450253c83238a7622bd755e142a