### PR TITLE
Normalize flow headers before sending to WhatsApp

### DIFF
--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -116,9 +116,25 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
         except Exception:
             opts = {}
 
-        header = opts.get("header")
-        if isinstance(header, str):
-            header = header.strip() or None
+        allowed_header_types = {"text"}
+        header_raw = opts.get("header")
+        header_text = None
+        header_type = "text"
+        if isinstance(header_raw, str):
+            header_text = header_raw.strip()
+        elif isinstance(header_raw, dict):
+            header_value = header_raw.get("text")
+            if header_value is not None:
+                header_text = str(header_value).strip()
+            header_type_candidate = header_raw.get("type")
+            if isinstance(header_type_candidate, str):
+                header_type_candidate = header_type_candidate.strip().lower() or None
+                if header_type_candidate in allowed_header_types:
+                    header_type = header_type_candidate
+        elif header_raw is not None:
+            header_text = str(header_raw).strip()
+        if header_text == "":
+            header_text = None
         footer = opts.get("footer")
         if isinstance(footer, str):
             footer = footer.strip() or None
@@ -189,8 +205,10 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             },
         }
 
-        if header:
-            data["interactive"]["header"] = {"type": "text", "text": header}
+        if header_text:
+            if header_type not in allowed_header_types:
+                header_type = "text"
+            data["interactive"]["header"] = {"type": header_type, "text": header_text}
         if footer:
             data["interactive"]["footer"] = {"text": footer}
 

--- a/tests/test_whatsapp_api.py
+++ b/tests/test_whatsapp_api.py
@@ -1,0 +1,88 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from services import whatsapp_api
+
+
+class DummyResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 300
+        self.text = json.dumps(payload)
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def stub_guardar(monkeypatch):
+    monkeypatch.setattr(whatsapp_api, "guardar_mensaje", lambda *args, **kwargs: None)
+
+
+@pytest.fixture
+def post_call(monkeypatch):
+    calls = {}
+
+    def fake_post(url, headers=None, json=None):
+        calls["url"] = url
+        calls["headers"] = headers
+        calls["payload"] = json
+        return DummyResponse({"messages": [{"id": "wamid.HASH"}]})
+
+    monkeypatch.setattr(whatsapp_api.requests, "post", fake_post)
+    return calls
+
+
+def test_flow_header_from_string(post_call):
+    opciones = json.dumps({
+        "header": "   Encabezado Flow   ",
+        "flow_cta": "CTA",
+        "flow_id": "FLOW123",
+        "mode": "draft",
+        "flow_action": "navigate",
+    })
+
+    result = whatsapp_api.enviar_mensaje(
+        numero="1234567890",
+        mensaje="Mensaje",
+        tipo="bot",
+        tipo_respuesta="flow",
+        opciones=opciones,
+    )
+
+    assert result is True
+    payload = post_call["payload"]
+    header = payload["interactive"]["header"]
+    assert header["type"] == "text"
+    assert header["text"] == "Encabezado Flow"
+    assert isinstance(header["text"], str)
+
+
+def test_flow_header_from_dict(post_call):
+    opciones = json.dumps({
+        "header": {"type": "image", "text": 12345},
+        "flow_cta": "CTA",
+        "flow_name": "Flow Name",
+        "mode": "published",
+        "flow_action": "navigate",
+    })
+
+    result = whatsapp_api.enviar_mensaje(
+        numero="0987654321",
+        mensaje="Otro mensaje",
+        tipo="bot",
+        tipo_respuesta="flow",
+        opciones=opciones,
+    )
+
+    assert result is True
+    header = post_call["payload"]["interactive"]["header"]
+    assert header["type"] == "text"
+    assert header["text"] == "12345"
+    assert isinstance(header["text"], str)


### PR DESCRIPTION
## Summary
- normalize flow interactive headers by accepting dict or string inputs and trimming the text payload
- default unsupported header types to text and skip the header when no clean text is available
- add pytest coverage to validate flow payloads built with string and dict headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e03ae97a2883239c04d4249794904f