### PR TITLE
Handle flow action payload variants

### DIFF
--- a/services/whatsapp_api.py
+++ b/services/whatsapp_api.py
@@ -170,9 +170,11 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             parameters_raw.get("flow_action_payload")
             or action_raw.get("flow_action_payload")
             or opts.get("flow_action_payload")
-            or {}
         )
-        if isinstance(payload_raw, dict):
+        if isinstance(payload_raw, str):
+            if payload_raw:
+                flow_parameters["flow_action_payload"] = payload_raw
+        elif isinstance(payload_raw, dict):
             payload = {}
             screen_value = payload_raw.get("screen")
             if isinstance(screen_value, str):
@@ -180,7 +182,7 @@ def enviar_mensaje(numero, mensaje, tipo='bot', tipo_respuesta='texto', opciones
             if screen_value:
                 payload["screen"] = screen_value
             data_value = payload_raw.get("data")
-            if data_value not in (None, ""):
+            if data_value not in (None, "", {}, []):
                 payload["data"] = data_value
             if payload:
                 flow_parameters["flow_action_payload"] = payload

--- a/tests/test_whatsapp_api.py
+++ b/tests/test_whatsapp_api.py
@@ -86,3 +86,74 @@ def test_flow_header_from_dict(post_call):
     assert header["type"] == "text"
     assert header["text"] == "12345"
     assert isinstance(header["text"], str)
+
+
+def test_flow_action_payload_accepts_string(post_call):
+    opciones = json.dumps({
+        "flow_cta": "CTA",
+        "flow_id": "FLOW123",
+        "flow_action_payload": "RAW_STRING_PAYLOAD",
+    })
+
+    result = whatsapp_api.enviar_mensaje(
+        numero="1111111111",
+        mensaje="Mensaje",
+        tipo="bot",
+        tipo_respuesta="flow",
+        opciones=opciones,
+    )
+
+    assert result is True
+    payload = (
+        post_call["payload"]["interactive"]["action"]["parameters"]["flow_action_payload"]
+    )
+    assert payload == "RAW_STRING_PAYLOAD"
+
+
+def test_flow_action_payload_cleans_dict(post_call):
+    opciones = json.dumps({
+        "flow_cta": "CTA",
+        "flow_name": "Flow Name",
+        "flow_action_payload": {
+            "screen": "   Screen Name   ",
+            "data": {"foo": "bar"},
+            "unused": "",
+        },
+    })
+
+    result = whatsapp_api.enviar_mensaje(
+        numero="2222222222",
+        mensaje="Mensaje",
+        tipo="bot",
+        tipo_respuesta="flow",
+        opciones=opciones,
+    )
+
+    assert result is True
+    payload = (
+        post_call["payload"]["interactive"]["action"]["parameters"]["flow_action_payload"]
+    )
+    assert payload == {"screen": "Screen Name", "data": {"foo": "bar"}}
+
+
+def test_flow_action_payload_omits_empty_values(post_call):
+    opciones = json.dumps({
+        "flow_cta": "CTA",
+        "flow_id": "FLOW456",
+        "flow_action_payload": {
+            "screen": "   ",
+            "data": {},
+        },
+    })
+
+    result = whatsapp_api.enviar_mensaje(
+        numero="3333333333",
+        mensaje="Mensaje",
+        tipo="bot",
+        tipo_respuesta="flow",
+        opciones=opciones,
+    )
+
+    assert result is True
+    parameters = post_call["payload"]["interactive"]["action"]["parameters"]
+    assert "flow_action_payload" not in parameters


### PR DESCRIPTION
## Summary
- allow flow flow_action_payload to accept raw string inputs and keep payloads untouched
- retain sanitization for dict payloads while omitting empty values
- add regression tests covering both string and dict payload paths

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e03bf546a88323a7a15811da31d1a5