### PR TITLE
Add AI keyword redirect for handoff step

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,6 +34,7 @@ class Config:
     AI_GEN_MODEL     = os.getenv('AI_GEN_MODEL', 'gpt-4o-mini')
     AI_MODE_DEFAULT  = _env_bool('AI_MODE_ENABLED', False)
     AI_HANDOFF_STEP  = os.getenv('AI_HANDOFF_STEP', 'ia_chat').strip().lower()
+    AI_KEYWORD_REDIRECT_STEP = os.getenv('AI_KEYWORD_REDIRECT_STEP', '').strip().lower()
     AI_VECTOR_STORE_PATH = os.getenv(
         'AI_VECTOR_STORE_PATH',
         os.path.join(BASEDIR, 'data', 'catalog_index')

--- a/config.py
+++ b/config.py
@@ -34,7 +34,7 @@ class Config:
     AI_GEN_MODEL     = os.getenv('AI_GEN_MODEL', 'gpt-4o-mini')
     AI_MODE_DEFAULT  = _env_bool('AI_MODE_ENABLED', False)
     AI_HANDOFF_STEP  = os.getenv('AI_HANDOFF_STEP', 'ia_chat').strip().lower()
-    AI_KEYWORD_REDIRECT_STEP = os.getenv('AI_KEYWORD_REDIRECT_STEP', '').strip().lower()
+    AI_KEYWORD_REDIRECT_STEP = os.getenv('AI_KEYWORD_REDIRECT_STEP', 'flow').strip().lower()
     AI_VECTOR_STORE_PATH = os.getenv(
         'AI_VECTOR_STORE_PATH',
         os.path.join(BASEDIR, 'data', 'catalog_index')

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -331,13 +331,29 @@ def handle_text_message(numero: str, texto: str, save: bool = True):
         process_step_chain(numero, 'iniciar')
         return
 
+    text_norm = normalize_text(texto or "")
+
     step_lower = (step_db or '').strip().lower()
     ai_step = (Config.AI_HANDOFF_STEP or '').strip().lower()
     if ai_step and step_lower == ai_step and is_ai_enabled():
+        redirect_step = (Config.AI_KEYWORD_REDIRECT_STEP or '').strip().lower()
+        keywords = {
+            "domicilio",
+            "comprar",
+            "pedido",
+            "entrega",
+            "envio",
+            "pagar",
+            "precio",
+            "llevar",
+        }
+        tokens = set(text_norm.split())
+        if redirect_step and tokens & keywords:
+            advance_steps(numero, redirect_step)
+            process_step_chain(numero)
+            return
         update_chat_state(numero, step_db, 'ia_pendiente')
         return
-
-    text_norm = normalize_text(texto or "")
 
     if handle_global_command(numero, texto):
         return

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from datetime import datetime
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from routes import webhook
+
+
+def test_handle_text_message_keyword_redirect(monkeypatch):
+    numero = "12345"
+    redirect_step = "flujo_compra"
+
+    monkeypatch.setattr(webhook.Config, "AI_HANDOFF_STEP", "ia_chat")
+    monkeypatch.setattr(webhook.Config, "AI_KEYWORD_REDIRECT_STEP", redirect_step)
+
+    monkeypatch.setattr(webhook, "get_chat_state", lambda _n: ("ia_chat", datetime.now()))
+    monkeypatch.setattr(webhook, "delete_chat_state", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webhook, "guardar_mensaje", lambda *args, **kwargs: None)
+    monkeypatch.setattr(webhook, "handle_global_command", lambda *args, **kwargs: False)
+    monkeypatch.setattr(webhook, "is_ai_enabled", lambda: True)
+
+    update_calls = []
+
+    def fake_update(numero_arg, step, estado=None):
+        update_calls.append((numero_arg, step, estado))
+
+    monkeypatch.setattr(webhook, "update_chat_state", fake_update)
+
+    advance_calls = []
+
+    def fake_advance(numero_arg, steps_str):
+        advance_calls.append((numero_arg, steps_str))
+
+    monkeypatch.setattr(webhook, "advance_steps", fake_advance)
+
+    process_calls = []
+
+    def fake_process(numero_arg, text_norm=None):
+        process_calls.append((numero_arg, text_norm))
+
+    monkeypatch.setattr(webhook, "process_step_chain", fake_process)
+
+    webhook.handle_text_message(numero, "Quiero hacer un pedido", save=False)
+
+    assert advance_calls == [(numero, redirect_step)]
+    assert process_calls == [(numero, None)]
+    assert all(call[2] != "ia_pendiente" for call in update_calls)


### PR DESCRIPTION
## Summary
- add configuration for the AI keyword redirect step
- detect configured keywords at the AI handoff step to advance and process the flow immediately
- cover the redirect behavior with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e059c65cd483238dd0e20ea0600399