### PR TITLE
Actualizar consultas de respuestas para filtrar mensajes de flow

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -146,7 +146,8 @@ def respuestas():
             """
             SELECT m.numero, m.mensaje, m.timestamp
               FROM mensajes m
-             WHERE m.tipo LIKE 'bot%%'
+              JOIN mensajes bot ON m.reply_to_wa_id = bot.wa_id
+             WHERE m.tipo = 'cliente' AND bot.tipo = 'bot_flow'
              ORDER BY m.timestamp DESC
             """
         )
@@ -156,8 +157,9 @@ def respuestas():
             """
             SELECT m.numero, m.mensaje, m.timestamp
               FROM mensajes m
+              JOIN mensajes bot ON m.reply_to_wa_id = bot.wa_id
               JOIN chat_roles cr ON m.numero = cr.numero
-             WHERE cr.role_id = %s AND m.tipo LIKE 'bot%%'
+             WHERE cr.role_id = %s AND m.tipo = 'cliente' AND bot.tipo = 'bot_flow'
              ORDER BY m.timestamp DESC
             """,
             (role_id,),


### PR DESCRIPTION
## Summary
- actualizar la consulta de respuestas para administradores con el JOIN a mensajes de flow y filtros por tipos
- aplicar el mismo JOIN y filtros para roles restringidos conservando la agrupación existente

## Testing
- no se pudieron ejecutar pruebas en este entorno (base de datos MySQL no disponible)


------
https://chatgpt.com/codex/tasks/task_e_68e068c7d5188323ab860d68ec4ce460