### PR TITLE
Organize flow responses for easier reading

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -534,6 +534,103 @@
     .back-btn:hover {
       background: var(--accent-hover);
     }
+
+    /* ----- Flow responses formatting ----- */
+    .flow-responses-list {
+      list-style: none;
+      padding-left: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .flow-response-item {
+      background: #f5f8ff;
+      border: 1px solid #d7e3ff;
+      border-radius: 12px;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .flow-response-header {
+      display: flex;
+      justify-content: flex-end;
+      font-size: 0.85rem;
+      color: #4f5d75;
+    }
+
+    .flow-response-card {
+      background: #ffffff;
+      border-left: 4px solid #4a90e2;
+      border-radius: 10px;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+    }
+
+    .flow-text {
+      margin: 0;
+      font-weight: 600;
+      color: #2c3e50;
+    }
+
+    .flow-data-list {
+      margin: 0;
+      padding-left: 1.2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .flow-data-object {
+      list-style: none;
+      padding-left: 0;
+    }
+
+    .flow-data-array {
+      list-style: decimal;
+    }
+
+    .flow-data-list > li {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .flow-key {
+      font-weight: 600;
+      color: #1f2d3d;
+    }
+
+    .flow-value-wrapper {
+      padding-left: 0.5rem;
+    }
+
+    .flow-value {
+      display: inline-block;
+      padding: 4px 8px;
+      background: #eef4ff;
+      border: 1px solid #d7e3ff;
+      border-radius: 8px;
+      color: #1f2d3d;
+      font-size: 0.95rem;
+      max-width: 100%;
+      word-break: break-word;
+    }
+
+    .bubble.flow-message .flow-response-card {
+      background: #eef4ff;
+      border-left-color: #2f80ed;
+    }
+
+    .bubble.flow-message .flow-text {
+      color: #1b2a4b;
+    }
 @media (min-width: 769px) {
   body.chat {
     overflow: hidden;

--- a/templates/index.html
+++ b/templates/index.html
@@ -83,6 +83,100 @@
         const lastChatTimestamps = {};
         const roleIcons = { ventas: '💼', soporte: '🛠', marketing: '📣' };
 
+        function normalizeFlowNode(value) {
+          if (Array.isArray(value)) {
+            return { type: 'list', items: value.map(normalizeFlowNode) };
+          }
+          if (value && typeof value === 'object') {
+            return {
+              type: 'object',
+              items: Object.entries(value).map(([key, val]) => ({
+                key,
+                value: normalizeFlowNode(val)
+              }))
+            };
+          }
+          return { type: 'value', value };
+        }
+
+        function buildFlowSegments(rawText) {
+          if (!rawText) return [];
+          const lines = rawText.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+          if (!lines.length) return [];
+          const segments = [];
+          lines.forEach(line => {
+            let parsed = null;
+            if (line.startsWith('{') || line.startsWith('[')) {
+              try {
+                parsed = JSON.parse(line);
+              } catch (err) {
+                parsed = null;
+              }
+            }
+            if (parsed === null) {
+              segments.push({ kind: 'text', content: line });
+            } else {
+              segments.push({ kind: 'data', content: normalizeFlowNode(parsed) });
+            }
+          });
+          return segments;
+        }
+
+        function renderFlowNode(node) {
+          if (node.type === 'object') {
+            const list = document.createElement('ul');
+            list.className = 'flow-data-list flow-data-object';
+            node.items.forEach(item => {
+              const li = document.createElement('li');
+              const label = document.createElement('span');
+              label.className = 'flow-key';
+              label.textContent = item.key;
+              li.appendChild(label);
+              const wrapper = document.createElement('div');
+              wrapper.className = 'flow-value-wrapper';
+              wrapper.appendChild(renderFlowNode(item.value));
+              li.appendChild(wrapper);
+              list.appendChild(li);
+            });
+            return list;
+          }
+          if (node.type === 'list') {
+            const list = document.createElement('ol');
+            list.className = 'flow-data-list flow-data-array';
+            node.items.forEach(item => {
+              const li = document.createElement('li');
+              const wrapper = document.createElement('div');
+              wrapper.className = 'flow-value-wrapper';
+              wrapper.appendChild(renderFlowNode(item));
+              li.appendChild(wrapper);
+              list.appendChild(li);
+            });
+            return list;
+          }
+          const span = document.createElement('span');
+          span.className = 'flow-value';
+          const value = node.value;
+          span.textContent = value === null || value === undefined || value === '' ? '—' : String(value);
+          return span;
+        }
+
+        function renderFlowSegments(segments) {
+          if (!segments.length) return null;
+          const container = document.createElement('div');
+          container.className = 'flow-response-card';
+          segments.forEach(segment => {
+            if (segment.kind === 'text') {
+              const p = document.createElement('p');
+              p.className = 'flow-text';
+              p.textContent = segment.content;
+              container.appendChild(p);
+            } else if (segment.kind === 'data') {
+              container.appendChild(renderFlowNode(segment.content));
+            }
+          });
+          return container;
+        }
+
         function playAlertSound() {
         const ctx = new (window.AudioContext || window.webkitAudioContext)();
         const oscillator = ctx.createOscillator();
@@ -311,7 +405,16 @@
               }
 
               // texto (caption o mensajes)
-              if (txt) {
+              let flowSegments = [];
+              if (tipo === 'cliente' && replyTipo === 'bot_flow') {
+                flowSegments = buildFlowSegments(txt);
+              }
+
+              if (flowSegments.length) {
+                div.classList.add('flow-message');
+                const flowCard = renderFlowSegments(flowSegments);
+                if (flowCard) div.appendChild(flowCard);
+              } else if (txt) {
                 const p = document.createElement('p');
                 p.textContent = txt;
                 div.appendChild(p);

--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -9,6 +9,28 @@
 </div>
 
 <h2>Respuestas</h2>
+{% macro render_flow_node(node) %}
+    {% if node.type == 'object' %}
+        <ul class="flow-data-list flow-data-object">
+            {% for item in node.items %}
+            <li>
+                <span class="flow-key">{{ item.key }}</span>
+                <div class="flow-value-wrapper">{{ render_flow_node(item.value) }}</div>
+            </li>
+            {% endfor %}
+        </ul>
+    {% elif node.type == 'list' %}
+        <ol class="flow-data-list flow-data-array">
+            {% for item in node.items %}
+            <li>
+                <div class="flow-value-wrapper">{{ render_flow_node(item) }}</div>
+            </li>
+            {% endfor %}
+        </ol>
+    {% else %}
+        <span class="flow-value">{{ node.value if node.value is not none and node.value != '' else '—' }}</span>
+    {% endif %}
+{% endmacro %}
 {% if flow_responses %}
 <table class="fixed-table">
     <thead>
@@ -24,9 +46,25 @@
             <td>
                 <ul class="flow-responses-list">
                     {% for resp in response.respuestas %}
-                    <li>
-                        <span class="flow-response-timestamp">{{ resp.timestamp }}</span>
-                        <div class="flow-response-message">{{ resp.mensaje }}</div>
+                    <li class="flow-response-item">
+                        <div class="flow-response-header">
+                            <span class="flow-response-timestamp">{{ resp.timestamp }}</span>
+                        </div>
+                        <div class="flow-response-body">
+                            {% if resp.segments %}
+                            <div class="flow-response-card">
+                                {% for segment in resp.segments %}
+                                    {% if segment.kind == 'text' %}
+                                        <p class="flow-text">{{ segment.content }}</p>
+                                    {% elif segment.kind == 'data' %}
+                                        {{ render_flow_node(segment.content) }}
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                            {% else %}
+                            <div class="flow-response-message">{{ resp.mensaje }}</div>
+                            {% endif %}
+                        </div>
                     </li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
## Summary
- parse stored flow replies into structured segments and send them to the template
- render flow replies in both the live chat view and the responses page with clearer cards and nested lists
- add styling to present flow data fields in an easy-to-scan layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58e5a08c08323ab5c668d71dc9759